### PR TITLE
deploy purge on bucket change for latexml conversion bucket

### DIFF
--- a/cloud_functions/purge_on_bucket_change/README.md
+++ b/cloud_functions/purge_on_bucket_change/README.md
@@ -6,6 +6,7 @@ Env vars:
 
 - ALWAYS_SOFT_PURGE optional, defaults off 1 or 0
 - DRY_RUN optional, defaults to off, 1 or 0
+- LATEXML_BUCKET, name of the bucket where html conversions are stored
 - FASTLY_PURGE_TOKEN, secret purge token for connecting to fastly
 
 # commands

--- a/cloud_functions/purge_on_bucket_change/cicd/env.purge_on_bucket_change.arxiv-development.yaml
+++ b/cloud_functions/purge_on_bucket_change/cicd/env.purge_on_bucket_change.arxiv-development.yaml
@@ -1,2 +1,3 @@
 ALWAYS_SOFT_PURGE: "0"
 DRY_RUN: "1"
+LATEXML_BUCKET: "latexml_arxiv_id_converted"

--- a/cloud_functions/purge_on_bucket_change/cicd/env.purge_on_bucket_change.arxiv-production.yaml
+++ b/cloud_functions/purge_on_bucket_change/cicd/env.purge_on_bucket_change.arxiv-production.yaml
@@ -1,2 +1,3 @@
 ALWAYS_SOFT_PURGE: "0"
 DRY_RUN: "0"
+LATEXML_BUCKET: "latexml_document_conversions"

--- a/cloud_functions/purge_on_bucket_change/cicd/pubsub_steps.yaml
+++ b/cloud_functions/purge_on_bucket_change/cicd/pubsub_steps.yaml
@@ -3,7 +3,7 @@ steps:
   - name: 'google/cloud-sdk'
     id: Deploy
     entrypoint: gcloud
-    args: ['functions', 'deploy', '${_FUNCTION_NAME}',
+    args: ['functions', 'deploy', '${_OUTPUT_FUNCTION_NAME}',
            '--retry',
            '--gen2',
            '--source', '${_SRCDIR}',

--- a/cloud_functions/purge_on_bucket_change/src/main.py
+++ b/cloud_functions/purge_on_bucket_change/src/main.py
@@ -53,7 +53,8 @@ def invalidate_for_gs_change(bucket: str, key: str, invalidator: Invalidator) ->
         logging.debug(f"No purge for ignored file type: gs://{bucket}/{key}")
         return
     
-    if bucket=="latexml_document_conversions":
+    latexml_bucket=os.environ.get('LATEXML_BUCKET', "latexml_document_conversions")
+    if bucket==latexml_bucket:
         path="html"
     elif "/pdf/" in key and key.endswith('.pdf'):
         path="pdf"

--- a/cloud_functions/purge_on_bucket_change/src/main.py
+++ b/cloud_functions/purge_on_bucket_change/src/main.py
@@ -55,7 +55,9 @@ def invalidate_for_gs_change(bucket: str, key: str, invalidator: Invalidator) ->
         logging.debug(f"No purge: gs://{bucket}/{key} not related to an arxiv paper id")
         return
     
-    if "/pdf/" in key and key.endswith('.pdf'):
+    if bucket=="latexml_document_conversions":
+        path="html"
+    elif "/pdf/" in key and key.endswith('.pdf'):
         path="pdf"
     elif '/html/' in key:
         path="html"

--- a/cloud_functions/purge_on_bucket_change/tests/test_purge_on_bucket_change.py
+++ b/cloud_functions/purge_on_bucket_change/tests/test_purge_on_bucket_change.py
@@ -38,6 +38,14 @@ def test_invalidate_keys():
     assert sorted(expected)==sorted(actual)
     mock_invalidator.reset_mock()
 
+    #latexml bucket
+    path="0802.3414v4/0802.3414v4.html"
+    invalidate_for_gs_change("latexml_document_conversions", path, mock_invalidator)
+    expected=["html-0802.3414v4", "html-0802.3414-current"]
+    actual=mock_invalidator.invalidate.call_args[0][0]
+    assert sorted(expected)==sorted(actual)
+    mock_invalidator.reset_mock()
+
     #pdf path
     path="ps_cache/cs/pdf/0712/0712.3116v2.pdf"
     invalidate_for_gs_change("bucket", path, mock_invalidator)


### PR DESCRIPTION
right now we only listen to production data so we dont catch changes to html conversions. this support a second copy of the cloud function that listens to the bucket html conversions store their files in